### PR TITLE
missing redux devtools dock monitor in devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.2.0",
     "redux-devtools": "^3.0.0",
+    "redux-devtools-dock-monitor": "^1.0.1",
     "redux-devtools-log-monitor": "^1.0.1",
     "redux-logger": "^2.3.2",
     "run-parallel": "^1.1.4",


### PR DESCRIPTION
yo! you know how much i love the devtools and their tiny, tiny arrows on the dropdowns! and with the dock-monitor dep missing, i can't enjoy furiously clicking to see the next level of state :smiley_cat: 

this must be the smallest pull req ever
